### PR TITLE
Updated progname for proxy

### DIFF
--- a/foreman.conf
+++ b/foreman.conf
@@ -47,12 +47,23 @@ if strlen($!thread_name) > 0 then {
         set $!foreman!org_label = $!org;
     }
     unset $!org;
-}
-if strlen($!FOREMAN_LOGGER) > 0 then {
-    set $!foreman!app = "foreman";
+} else if ($programname == 'foreman') or ($programname == 'smart-proxy') or ($programname == 'foreman-proxy') then {
+    # Set the app field first
+    if ($programname == 'foreman') then {
+      set $!foreman!app = "foreman";
+      set $!foreman!logger = $!FOREMAN_LOGGER;
+      unset $!FOREMAN_LOGGER;
+    } else if ($programname == 'smart-proxy') or ($programname == 'foreman-proxy') then {
+      # Logging through STDOUT->journal is sent as "smart-proxy", otherwise "foreman-proxy"
+      set $!foreman!app = "foreman-proxy";
+      if strlen($!PROXY_LOGGER) > 0 then {
+        set $!foreman!logger = $!PROXY_LOGGER;
+      } else {
+        set $!foreman!logger = "proxy";
+      }
+      unset $!PROXY_LOGGER;
+    }
     # Process fields from foreman (logger-journald rubygem)
-    set $!foreman!logger = $!FOREMAN_LOGGER;
-    unset $!FOREMAN_LOGGER;
     if strlen($!REQUEST) > 0 then {
         set $!foreman!request = $!REQUEST;
     }
@@ -445,15 +456,11 @@ template(name="candlepin_logfile_template" type="list") {
 
 if $!foreman!logger == 'audit' then {
     action(type="omfile" file="/var/log/foreman/audit.log" template="audit_logfile_template")
-}
-if $programname == 'foreman' then {
+} else if $programname == 'foreman' then {
     action(type="omfile" file="/var/log/foreman/production.log" template="foreman_logfile_template")
-}
-if $programname == 'smart-proxy' then {
-    set $!foreman!app = "foreman-proxy";
+} else if $programname == 'smart-proxy' then {
     action(type="omfile" file="/var/log/foreman-proxy/proxy.log" template="proxy_logfile_template")
-}
-if $!foreman!app == 'candlepin' then {
+} else if $!foreman!app == 'candlepin' then {
     action(type="omfile" file="/var/log/candlepin/candlepin.log" template="candlepin_logfile_template")
 }
 


### PR DESCRIPTION
Couple of changes @swadeley 

* Let's use generic 0.0.0.0 instead of giving it IP addresses.
* Package `foreman-proxy-journald` was actually missing in instructions, therefore proxy was not logging via systemd-journald but via STDOUT-journald without any structured fields.
* Fixed proxy transformations in the main configuration.
* Small remarks here and there.